### PR TITLE
Atualmente o .gitignore não funciona conforme esperado

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-./*/**/manifest.json
 ./*/**/dist
 .env*
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-*/node_modules
-*/**/manifest.json
-*/**/dist
+node_modules/
+./*/**/manifest.json
+./*/**/dist
+.env*
+dist/
+package-lock.json


### PR DESCRIPTION
- [x] - O .gitignore do template agora ignora os seguintes conteúdos que são importantes
     - [x]  node_modules | Pasta de pacotes javascript do projeto
     - [x]  .env | Arquivos de variáveis de ambiente
     - [x]  dist | Pasta com o build das extensões
     - [x]  package-lock | Arquivo de controle de versão dos pacotes instalados localmente
     - [x]  manifest.json | Por algum motivo estava no .gitignore mas acredito que é melhor que esteja no repositório, porque caso contrário todos os usuários teriam que ficar fazendo qt link para cada extensão existente e no caso de um projeto completo com muitas extensões ficaria muito moroso e até perigoso caso alguma extensão fosse linkada erroneamente.